### PR TITLE
fix: Account selection on transaction page

### DIFF
--- a/src/app/api/[[...route]]/transactions.ts
+++ b/src/app/api/[[...route]]/transactions.ts
@@ -60,7 +60,7 @@ const app = new Hono()
         .leftJoin(categories, eq(transactions.categoryId, categories.id))
         .where(
           and(
-            accountId ? eq(transactions.accountId, accounts.id) : undefined,
+            accountId ? eq(transactions.accountId, accountId) : undefined,
             eq(accounts.userId, auth.userId),
             gte(transactions.date, startDate),
             lte(transactions.date, endDate),


### PR DESCRIPTION
Fixes #1

Updated the reference to 'accountId' to ensure proper functionality.